### PR TITLE
Make updates for autonomous runs

### DIFF
--- a/launch/mavros.launch
+++ b/launch/mavros.launch
@@ -14,7 +14,8 @@
   <arg name="log_output" default="screen"/>
 
   <!-- Launch heartbeat node to kill the sub on connection loss -->
-  <node pkg="robosub" type="heartbeat.sh" name="heartbeat" required="true" output="$(arg log_output)" unless="$(arg sitl)"/>
+  <!--node pkg="robosub" type="heartbeat.sh" name="heartbeat" required="true"
+      output="$(arg log_output)" unless="$(arg sitl)"/-->
 
   <!-- Launch mavros with SITL -->
   <include file="$(find bluerov_ros_playground)/launch/gazebo_sitl.launch" if="$(arg sitl)" >
@@ -37,7 +38,4 @@
     <rosparam command="load" file="$(arg pluginlists_yaml)"/>
     <rosparam command="load" file="$(arg config_yaml)"/>
   </node>
-
-  <!-- load ardupilot parameters onto the pixhawk -->
-  <node pkg="mavros" type="mavparam" args="load $(find robosub)/tools/ardupilot/mav.parm" />
 </launch>

--- a/start-sub.sh
+++ b/start-sub.sh
@@ -3,14 +3,18 @@
 # Script that starts the submarine. Should be called by hand or on boot by
 # systemd
 
-set -xeu
+set -xu
 
-# Maxmize the jetson's performance
+# Remove old files if they exist
+sudo rm /home/ubuntu/l4t_dfs.conf
+
+# Maximize the jetson's performance
+set -e
 sudo /home/ubuntu/jetson_clocks.sh --store
 trap "sudo /home/ubuntu/jetson_clocks.sh --restore" EXIT
 
 # Add all necessary launch files here
 roslaunch robosub motion.launch &
-roslaunch robosub bottom-camera.launch &
+# roslaunch robosub bottom-camera.launch &
 
 wait


### PR DESCRIPTION
This makes the start-sub.sh script more robust and removes the heartbeat checker for a tether connection.

To restart the sub mission, run `sudo systemctl restart submarine`